### PR TITLE
Sender code reverted to old code meeting limit in printing

### DIFF
--- a/bms_sender.c
+++ b/bms_sender.c
@@ -1,5 +1,4 @@
 #include "bms.h"
-#include "unistd.h"
 
 /* Structure initialisation of battery parameters */
 struct BatteryParam_s BatteryParam[NUMOFPARAM] = {{"Temperature", TEMP_MIN , TEMP_MAX},
@@ -21,7 +20,7 @@ void BMSDataToConsoleSender()
 	float BMSParamValue[NUMOFPARAM];
     int EoFDetected = 0 ; 
 	char seperator;
-	int count = 0;
+	
 	if( SenderPrintFormat == CSV) /*Needed only for CSV format as the param names are typed before data
 									In other formats it is typed along with data say JSON*/
 	{
@@ -36,12 +35,12 @@ void BMSDataToConsoleSender()
 	do
 	{
 	    EoFDetected = 0;
-	    count++;
+	    
 	    for (int i=0 ; i < NUMOFPARAM; i++)
 	    {
 	        BMSParamValue[i]= getParamValue[i]();
 	        
-	        if (BMSParamValue[i] == EOF || (maxCount > 0 && count == maxCount)) //to provide facility to print only required number of lines
+	        if (BMSParamValue[i] == EOF)
 	        {
 	            EoFDetected ++ ;
 	        }
@@ -52,8 +51,6 @@ void BMSDataToConsoleSender()
 	    sleep(SENDER_DELAY_SEC);
 	    
 	}while(!(EoFDetected == NUMOFPARAM));
-	if(maxCount > 0){
-		printf("-1.00;-1.00"); //to keep last result same as EOF using ctrl+C
-	}
+
 }
 

--- a/bmsdata_func.c
+++ b/bmsdata_func.c
@@ -23,8 +23,9 @@ void printToConsole(float * BMSDataArray , int arraySize, enum PRINTFORMAT Sende
 
 float getBMSTemperatue()
 {
+    static int i=0;
     float retval; 
-	if(sig_caught == true)
+	if((sig_caught == true)||(i > maxCount ))
 	{
 		retval  = EOF;
 	}
@@ -32,6 +33,7 @@ float getBMSTemperatue()
 	{
 	    retval  = RandomFloatGeneratorWithinRange(TEMP_MIN, TEMP_MAX);
 	}
+	i++;
 
     return retval ;
 }
@@ -46,10 +48,10 @@ float getBMSTemperatue()
 
 float getBMSChargeRate()
 {
-
+    static int i=0;
     float retval;
   
-    if(sig_caught == true)
+    if((sig_caught == true)||(i > maxCount ))
 	{
 		retval = EOF;
 	}
@@ -57,7 +59,8 @@ float getBMSChargeRate()
 	{
 	    retval  = RandomFloatGeneratorWithinRange(CHRGRATE_MIN, CHRGRATE_MAX) ;
 	}
-	
+	i++;
+
     return retval ;
 }
 

--- a/test_main.c
+++ b/test_main.c
@@ -16,7 +16,7 @@ float TestInputValue[NUMOFPARAM] = {0,0};
 float TestOutputValue[NUMOFPARAM] = {0,0};
 int MAX_PRINT[NUMOFPARAM] = {0,0};
 int TestPrintCount[NUMOFPARAM] = {0,0};
-int maxCount = 0;
+
 void ResetPrintCount()
 {
     TestPrintCount[TEMPERATURE] = 0;

--- a/test_mocks.h
+++ b/test_mocks.h
@@ -25,7 +25,7 @@ extern float TestInputValue[NUMOFPARAM];
 extern float TestOutputValue[NUMOFPARAM];
 extern int MAX_PRINT[NUMOFPARAM];
 extern int TestPrintCount[NUMOFPARAM];
-extern int maxCount;
+
 /**************************************************************/
 
 /**************Function prototype section**********************/


### PR DESCRIPTION
The sender code was modified by receiver person for printing limited number of output in production mode
But sender has user request to stop in production mode
For pipelining need, in this repo, it a limit in number of data printed is introduced in Sender Production mode